### PR TITLE
feat: エージェントごとの上書き設定を追加

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,10 +1,17 @@
 # --- Agent Definitions ---
 agents:
-  Agent1.template: marketing_research
-  Agent2.template: lateral_thinking
-  Agent3.template: software_engineer
+  Agent1:
+    template: marketing_research
+    overwrite: true
+  Agent2:
+    template: lateral_thinking
+    overwrite: false
+  Agent3:
+    template: software_engineer
+    # If overwrite is not specified, it defaults to false.
 
 # --- Directory Settings ---
+# The global overwrite_existing_agents is no longer needed.
 source_dir: /app/ai_worker
 destination_dir: /app/works
 


### PR DESCRIPTION
start_session.py と config.yaml を変更し、エージェントのディレクトリを上書きするかどうかをエージェントごとに設定できるようにしました。

config.yaml で `overwrite: true` を指定したエージェントのみが、セッション開始時にテンプレートから再作成されます。指定がない場合や `false` の場合は、既存のディレクトリが維持されます。